### PR TITLE
change title for reader.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <title>./translated.md</title>
+  <title>Code Review Best Practices 日本語翻訳</title>
   <meta name="author" content="pankona" />
   <link rel="stylesheet" href="./screen.css" type="text/css" />
   <link rel="icon" href="favicon.ico" />


### PR DESCRIPTION
はてぶしたときに、見だしが「./translate.md」になってしまったので、
はてぶでもちゃんとしたタイトルが表示されるように
title要素の記述を修正しました。
