### PR TITLE
[#4] set page title instead of file name (translated.md) when html page is generated by script

### DIFF
--- a/generate_html.sh
+++ b/generate_html.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
 ./gfm2html.rb -s ./screen.css -g -n pankona ./translated.md > index.html
+
+tmpfile=$(mktemp 2>/dev/null||mktemp -t tmp)
+cat ./index.html | sed -e "s/<title>\.\/translated\.md<\/title>/<title>Code Review Best Practices 日本語翻訳<\/title>/g" > $tmpfile
+cp $tmpfile index.html
+rm $tmpfile
+  

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <title>./translated.md</title>
+  <title>Code Review Best Practices 日本語翻訳</title>
   <meta name="author" content="pankona" />
   <link rel="stylesheet" href="./screen.css" type="text/css" />
   <link rel="icon" href="favicon.ico" />


### PR DESCRIPTION
## Pull Request for issue #4
## Updates
- html page generator replaces `<title>` header of index.html to make it more suitable. 
### Status of Pull Request
- [x] Implement
- [x] Behavior validation on PC
